### PR TITLE
Rejuvenate log levels

### DIFF
--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
@@ -44,7 +44,7 @@ public class DefaultErrorDialogHandler extends AErrorDialogHandler {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
-        logger.log(Level.INFO,sw.toString());
+        logger.log(Level.FINEST,sw.toString());
         return new DefaultErrorDialog("Error Pane",sw.toString());
     }
 }

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ShutdownThreadsHandler.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ShutdownThreadsHandler.java
@@ -76,7 +76,7 @@ public final class ShutdownThreadsHandler{
 	public static void shutdownThreads() {
 		FXWorker.APPLICATION_RUNNING.set(false);
 		registeredThreads.stream().filter(t -> t.isAlive()).forEach(t -> {
-			logger.info("shutdown thread: " + t);
+			logger.finest("shutdown thread: " + t);
 			t.interrupt();
 		});
 	}
@@ -93,7 +93,7 @@ public final class ShutdownThreadsHandler{
 	public static void shutdowAll() {
 		FXWorker.APPLICATION_RUNNING.set(false);
 		registeredThreads.stream().filter(t -> t.isAlive()).forEach(t -> {
-			logger.info("shutdown thread: " + t);
+			logger.finest("shutdown thread: " + t);
 			t.interrupt();
 		});
 		registeredExecutors.forEach(java.util.concurrent.ExecutorService::shutdown);

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
@@ -174,7 +174,7 @@ public class WorkbenchUtil {
         final String id = perspectiveAnnotation.id();
         if (id == null) throw new IllegalArgumentException("no perspective id set");
         initContext(InternalContext.class.cast(perspective.getContext()), parentId, id, perspectiveAnnotation.active());
-        LOGGER.fine("register perspective with annotations : "
+        LOGGER.finest("register perspective with annotations : "
                 + perspectiveAnnotation.id());
         initDeclarativePerspectiveParts(perspective, perspectiveAnnotation);
         initLocaleAttributes(perspective, perspectiveAnnotation);

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/workbench/AFXWorkbench.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/workbench/AFXWorkbench.java
@@ -164,7 +164,7 @@ public abstract class AFXWorkbench
         FXUtil.performResourceInjection(handle, context);
         start(Stage.class.cast(root));
         GlobalMediator.getInstance().handleWorkbenchToolBarButtons(annotation.id(), true);
-        logger.info("INIT");
+        logger.finest("INIT");
     }
 
     private Workbench getWorkbenchAnnotation() {


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | enclosing method | DOI value
-- | -- | -- | -- | --
logger.info("shutdown   thread: " + t) | INFO | FINEST | shutdowAll() | 0
logger.info("INIT") | INFO | FINEST | init(org.jacpfx.api.launcher.Launcher,java.lang.Object) | 0
LOGGER.fine("register perspective   with annotations : " + perspectiveAnnotation.id()) | FINE | FINEST | handleMetaAnnotation(org.jacpfx.api.component.Perspective,java.lang.String) | 0
logger.log(Level.INFO,sw.toString()) | INFO | FINEST | createExceptionDialog(java.lang.Throwable) | 0
logger.info("shutdown thread: "   + t) | INFO | FINEST | shutdownThreads() | 0



## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat CONFIG log level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
jacpfx.API | [0.0, 0.26783332) | FINEST
jacpfx.API | [0.26783332, 0.53566664) | FINER
jacpfx.API | [0.53566664, 0.80349994) | FINE
jacpfx.API | [0.80349994, 1.0713333) | INFO
jacpfx.API | [1.0713333, 1.3391666) | WARNING
jacpfx.API | [1.3391666, 1.6069999) | SEVERE
jacpfx.JavaFX | [0.0, 0.8120003) | FINEST
jacpfx.JavaFX | [0.8120003, 1.6240005) | FINER
jacpfx.JavaFX | [1.6240005, 2.4360008) | FINE
jacpfx.JavaFX | [2.4360008, 3.248001) | INFO
jacpfx.JavaFX | [3.248001, 4.0600014) | WARNING
jacpfx.JavaFX | [4.0600014, 4.8720016) | SEVERE
jacpfx.JavaFXLauncher | [0.0, 0.22483349) | FINEST
jacpfx.JavaFXLauncher | [0.22483349, 0.44966698) | FINER
jacpfx.JavaFXLauncher | [0.44966698, 0.67450047) | FINE
jacpfx.JavaFXLauncher | [0.67450047, 0.89933395) | INFO
jacpfx.JavaFXLauncher | [0.89933395, 1.1241674) | WARNING
jacpfx.JavaFXLauncher | [1.1241674, 1.3490009) | SEVERE
JacpFXConcurrencyTools | [0.0, 0.60849994) | FINEST
JacpFXConcurrencyTools | [0.60849994, 1.2169999) | FINER
JacpFXConcurrencyTools | [1.2169999, 1.8254998) | FINE
JacpFXConcurrencyTools | [1.8254998, 2.4339998) | INFO
JacpFXConcurrencyTools | [2.4339998, 3.0424998) | WARNING
JacpFXConcurrencyTools | [3.0424998, 3.6509995) | SEVERE

