### PR TITLE
Rejuvenate log levels

### DIFF
--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/handler/DefaultErrorDialogHandler.java
@@ -44,7 +44,7 @@ public class DefaultErrorDialogHandler extends AErrorDialogHandler {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
-        logger.log(Level.INFO,sw.toString());
+        logger.log(Level.FINEST,sw.toString());
         return new DefaultErrorDialog("Error Pane",sw.toString());
     }
 }

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ShutdownThreadsHandler.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/ShutdownThreadsHandler.java
@@ -76,7 +76,7 @@ public final class ShutdownThreadsHandler{
 	public static void shutdownThreads() {
 		FXWorker.APPLICATION_RUNNING.set(false);
 		registeredThreads.stream().filter(t -> t.isAlive()).forEach(t -> {
-			logger.info("shutdown thread: " + t);
+			logger.finest("shutdown thread: " + t);
 			t.interrupt();
 		});
 	}
@@ -93,7 +93,7 @@ public final class ShutdownThreadsHandler{
 	public static void shutdowAll() {
 		FXWorker.APPLICATION_RUNNING.set(false);
 		registeredThreads.stream().filter(t -> t.isAlive()).forEach(t -> {
-			logger.info("shutdown thread: " + t);
+			logger.finest("shutdown thread: " + t);
 			t.interrupt();
 		});
 		registeredExecutors.forEach(java.util.concurrent.ExecutorService::shutdown);

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/util/WorkbenchUtil.java
@@ -174,7 +174,7 @@ public class WorkbenchUtil {
         final String id = perspectiveAnnotation.id();
         if (id == null) throw new IllegalArgumentException("no perspective id set");
         initContext(InternalContext.class.cast(perspective.getContext()), parentId, id, perspectiveAnnotation.active());
-        LOGGER.fine("register perspective with annotations : "
+        LOGGER.finest("register perspective with annotations : "
                 + perspectiveAnnotation.id());
         initDeclarativePerspectiveParts(perspective, perspectiveAnnotation);
         initLocaleAttributes(perspective, perspectiveAnnotation);

--- a/JACP.JavaFX/src/main/java/org/jacpfx/rcp/workbench/AFXWorkbench.java
+++ b/JACP.JavaFX/src/main/java/org/jacpfx/rcp/workbench/AFXWorkbench.java
@@ -164,7 +164,7 @@ public abstract class AFXWorkbench
         FXUtil.performResourceInjection(handle, context);
         start(Stage.class.cast(root));
         GlobalMediator.getInstance().handleWorkbenchToolBarButtons(annotation.id(), true);
-        logger.info("INIT");
+        logger.finest("INIT");
     }
 
     private Workbench getWorkbenchAnnotation() {


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:

log expression | original log level | transformed log level | enclosing method | DOI value
-- | -- | -- | -- | --
logger.info("shutdown   thread: " + t) | INFO | FINEST | shutdownThreads() | 0
LOGGER.fine("register perspective   with annotations : " + perspectiveAnnotation.id()) | FINE | FINEST | handleMetaAnnotation(org.jacpfx.api.component.Perspective,java.lang.String) | 0
logger.info("INIT") | INFO | FINEST | init(org.jacpfx.api.launcher.Launcher,java.lang.Object) | 0
logger.log(Level.INFO,sw.toString()) | INFO | FINEST | createExceptionDialog(java.lang.Throwable) | 0
logger.info("shutdown thread: "   + t) | INFO | FINEST | shutdowAll() | 0




## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG/WARNING/SEVERE level as a category and not a traditional level, i.e., our tool ignores CONFIG/WARNING/SEVERE log level (setting 1).
- Never lower the logging level of logging statements within catch blocks (setting 2).

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
jacpfx.API | [0.0, 0.40174997) | FINEST
jacpfx.API | [0.40174997, 0.80349994) | FINER
jacpfx.API | [0.80349994, 1.2052499) | FINE
jacpfx.API | [1.2052499, 1.6069999) | INFO
jacpfx.JavaFX | [0.0, 1.2180004) | FINEST
jacpfx.JavaFX | [1.2180004, 2.4360008) | FINER
jacpfx.JavaFX | [2.4360008, 3.6540012) | FINE
jacpfx.JavaFX | [3.6540012, 4.8720016) | INFO
jacpfx.JavaFXLauncher | [0.0, 0.33725023) | FINEST
jacpfx.JavaFXLauncher | [0.33725023, 0.67450047) | FINER
jacpfx.JavaFXLauncher | [0.67450047, 1.0117507) | FINE
jacpfx.JavaFXLauncher | [1.0117507, 1.3490009) | INFO
JacpFXConcurrencyTools | [0.0, 0.91274995) | FINEST
JacpFXConcurrencyTools | [0.91274995, 1.8254999) | FINER
JacpFXConcurrencyTools | [1.8254999, 2.7382498) | FINE
JacpFXConcurrencyTools | [2.7382498, 3.6509998) | INFO


